### PR TITLE
ImageReference is not found. Now, this is the correct method

### DIFF
--- a/GridViewPager/Wearable/src/main/java/com/example/android/wearable/gridviewpager/SampleGridPagerAdapter.java
+++ b/GridViewPager/Wearable/src/main/java/com/example/android/wearable/gridviewpager/SampleGridPagerAdapter.java
@@ -117,8 +117,8 @@ public class SampleGridPagerAdapter extends FragmentGridPagerAdapter {
     }
 
     @Override
-    public ImageReference getBackground(int row, int column) {
-        return ImageReference.forDrawable(BG_IMAGES[row % BG_IMAGES.length]);
+    public Drawable getBackgroundForRow(int row) {
+        return  mContext.getResources().getDrawable(BG_IMAGES[row]);
     }
 
     @Override


### PR DESCRIPTION
You can see here:
http://stackoverflow.com/questions/28285492/cannot-resolve-symbol-imagereference

or here:
http://stackoverflow.com/questions/29869507/android-wear-cannot-resolve-image-reference

Now, this example compiles perfectly
